### PR TITLE
Implement Carousel through Netlify CMS

### DIFF
--- a/content/pages/home.md
+++ b/content/pages/home.md
@@ -2,7 +2,6 @@
 template: HomePage
 slug: ""
 title: Morris Public Library
-featuredImage: https://ucarecdn.com/1d7ea5f5-317f-4546-8914-3dd443a8b2ca/
 subtitle: "**Work in progress**"
 meta:
   description: This is a meta description.

--- a/content/pages/home.md
+++ b/content/pages/home.md
@@ -3,8 +3,11 @@ template: HomePage
 carousel:
   images:
     - image: 'https://ucarecdn.com/73e04457-506e-4040-9a8c-30895021ef38/'
+      alt: 'volunteers'
     - image: 'https://ucarecdn.com/af6cd617-ffad-42ac-a757-19795ea9e632/'
+      alt: 'new computers'
     - image: 'https://ucarecdn.com/289987dd-fa16-45b4-9841-4c17764d0b75/'
+      alt: 'book stack'
 slug: ''
 title: Morris Public Library
 subtitle: '**Work in progress**'

--- a/content/pages/home.md
+++ b/content/pages/home.md
@@ -1,9 +1,13 @@
 ---
 template: HomePage
-slug: ""
+carousel:
+  images:
+    - image: 'https://ucarecdn.com/73e04457-506e-4040-9a8c-30895021ef38/'
+    - image: 'https://ucarecdn.com/af6cd617-ffad-42ac-a757-19795ea9e632/'
+    - image: 'https://ucarecdn.com/289987dd-fa16-45b4-9841-4c17764d0b75/'
+slug: ''
 title: Morris Public Library
-featuredImage: https://ucarecdn.com/1d7ea5f5-317f-4546-8914-3dd443a8b2ca/
-subtitle: "**Work in progress**"
+subtitle: '**Work in progress**'
 meta:
   description: This is a meta description.
   title: The Ultimate Gatsby Starter

--- a/package-lock.json
+++ b/package-lock.json
@@ -6933,6 +6933,11 @@
         }
       }
     },
+    "enquire.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
+      "integrity": "sha1-PoeAybi4NQhMP2DhZtvDwqPImBQ="
+    },
     "entities": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
@@ -9177,6 +9182,24 @@
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "gatsby-plugin-google-tagmanager": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-2.3.4.tgz",
+      "integrity": "sha512-81WLvTQUOJSAlXZZ8Aqz5Cw36w0y2BsHJjWc5VKC83W8NMXoE6nx1SY/iOKNjWWLoW43QlVlsYU/CFqEPbMySA==",
+      "requires": {
+        "@babel/runtime": "^7.10.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
           }
         }
       }
@@ -13192,6 +13215,14 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
+      "requires": {
+        "string-convert": "^0.2.0"
+      }
     },
     "json3": {
       "version": "3.3.3",
@@ -18572,6 +18603,18 @@
         "shallowequal": "^1.0.1"
       }
     },
+    "react-slick": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.26.1.tgz",
+      "integrity": "sha512-IQVRSkikG2w5bkz+m9Ing5zZIuM9cI+qJyXG2o6PXHKj8GFcsMCJoTBADwyLSsVT8dHcZ8MZ0dsxq0i0CKIq+Q==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "enquire.js": "^2.1.6",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
+      }
+    },
     "react-sortable-hoc": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz",
@@ -19523,6 +19566,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "resolve": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -20370,6 +20418,11 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA=="
+    },
     "slugify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.0.tgz",
@@ -21027,6 +21080,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+    },
+    "string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c="
     },
     "string-length": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18301,6 +18301,14 @@
         }
       }
     },
+    "react-easy-swipe": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/react-easy-swipe/-/react-easy-swipe-0.0.18.tgz",
+      "integrity": "sha512-IddCZANbT0qVbGFEihfWOkZb/rFpeA3VV87SNOOqPzmSZ93G0nDSyHD28zuGhYJilwEP33MqYv/dwo+zaZha3Q==",
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-error-overlay": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-3.0.0.tgz",
@@ -18505,6 +18513,16 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.7.2.tgz",
       "integrity": "sha512-u5l7fhAJXecWUJzVxzMRU2Zvw8m4QmDNHlTrT5uo3KBlYBhmChd7syAakBoay1yIiVhx/8Fi7a6v6kQZfsw81Q=="
+    },
+    "react-responsive-carousel": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/react-responsive-carousel/-/react-responsive-carousel-3.2.7.tgz",
+      "integrity": "sha512-uqGCnoZukU+U1relhTNe8eVX/hMT5ELh1uxHCOxR6cH+A67eG2aX68e1pJnohWqXqPj/u+Pupt1q5j8LGhDabA==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.5.8",
+        "react-easy-swipe": "^0.0.18"
+      }
     },
     "react-router": {
       "version": "4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6933,11 +6933,6 @@
         }
       }
     },
-    "enquire.js": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
-      "integrity": "sha1-PoeAybi4NQhMP2DhZtvDwqPImBQ="
-    },
     "entities": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
@@ -13216,14 +13211,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
-    "json2mq": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
-      "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
-      "requires": {
-        "string-convert": "^0.2.0"
-      }
-    },
     "json3": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
@@ -18621,18 +18608,6 @@
         "shallowequal": "^1.0.1"
       }
     },
-    "react-slick": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.26.1.tgz",
-      "integrity": "sha512-IQVRSkikG2w5bkz+m9Ing5zZIuM9cI+qJyXG2o6PXHKj8GFcsMCJoTBADwyLSsVT8dHcZ8MZ0dsxq0i0CKIq+Q==",
-      "requires": {
-        "classnames": "^2.2.5",
-        "enquire.js": "^2.1.6",
-        "json2mq": "^0.2.0",
-        "lodash.debounce": "^4.0.8",
-        "resize-observer-polyfill": "^1.5.0"
-      }
-    },
     "react-sortable-hoc": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz",
@@ -19584,11 +19559,6 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
-    "resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
-    },
     "resolve": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -20436,11 +20406,6 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
-    "slick-carousel": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
-      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA=="
-    },
     "slugify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.0.tgz",
@@ -21098,11 +21063,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
-    },
-    "string-convert": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
-      "integrity": "sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c="
     },
     "string-length": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,7 @@
     "react-helmet": "^5.2.1",
     "react-markdown": "^4.2.2",
     "react-photoswipe": "^1.3.0",
-    "react-responsive-carousel": "^3.2.7",
-    "react-slick": "^0.26.1",
-    "slick-carousel": "^1.8.1"
+    "react-responsive-carousel": "^3.2.7"
   },
   "keywords": [
     "gatsby"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-helmet": "^5.2.1",
     "react-markdown": "^4.2.2",
     "react-photoswipe": "^1.3.0",
+    "react-responsive-carousel": "^3.2.7",
     "react-slick": "^0.26.1",
     "slick-carousel": "^1.8.1"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "react-feather": "^2.0.8",
     "react-helmet": "^5.2.1",
     "react-markdown": "^4.2.2",
-    "react-photoswipe": "^1.3.0"
+    "react-photoswipe": "^1.3.0",
+    "react-slick": "^0.26.1",
+    "slick-carousel": "^1.8.1"
   },
   "keywords": [
     "gatsby"

--- a/src/templates/HomePage.css
+++ b/src/templates/HomePage.css
@@ -2,6 +2,12 @@
     .smallDisplay {
         display: none;
     }
+    
+    /* If we only want to limit the height of carousel for bigger screens. See more below */
+    /* .carousel .slide img {
+        max-height: 30vmax; 
+        width: auto;
+    } */
  }
 
  @media (max-width: 550px) {
@@ -13,3 +19,43 @@
 iframe {
     width: 100%;
 }
+
+
+/* METHOD 1:
+    Since the images are too big on laptop and desktop screens, this limits the max height to be a ratio of the viewport making all 
+    images the same height. Setting width:0 adds black to both side of the image and keeps the aspect ratio the same
+    while not declaring width streteches the image to fill the width. Can also just be applied to larger screens insdie the media query above. */
+
+/* 
+.carousel .slide img {
+    max-height: 30vmax; 
+    width: auto;
+}  */
+
+
+
+/* METHOD 2:
+    The first two below are a part of the background-image method. For our setup, I needed to put the image in html(since the carousel's 
+    height is determined by it's content) and make opacity of images 0 to properly use the background method.
+    See the bottom of HomePage.js for more info */
+
+/*.carousel-wrapper,
+.carousel,
+.carousel > .slider-wrapper,
+.carousel > .slider-wrapper > .slider {
+  height: 100%;
+} */
+
+/* .image-container {
+  height: 100%;
+  width: 100%;
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center;
+} */
+
+/* 
+.carousel .slide img {
+    max-height: 30vmax; 
+    opacity: 0
+} */

--- a/src/templates/HomePage.css
+++ b/src/templates/HomePage.css
@@ -4,14 +4,20 @@
     }
     
     /* If we only want to limit the height of carousel for bigger screens. See more below */
-    /* .carousel .slide img {
+    .carousel .slide img {
         max-height: 30vmax; 
-        width: auto;
-    } */
+        width: cover;
+    }
+    .carousel-smallDisplay {
+        display: none;
+    }
  }
 
  @media (max-width: 550px) {
     .largeDisplay {
+        display: none;
+    }
+    .carousel-largeDisplay {
         display: none;
     }
  }
@@ -26,8 +32,8 @@ iframe {
     images the same height. Setting width:0 adds black to both side of the image and keeps the aspect ratio the same
     while not declaring width streteches the image to fill the width. Can also just be applied to larger screens insdie the media query above. */
 
-/* 
-.carousel .slide img {
+
+/* .carousel .slide img {
     max-height: 30vmax; 
     width: auto;
 }  */

--- a/src/templates/HomePage.css
+++ b/src/templates/HomePage.css
@@ -13,37 +13,3 @@
 iframe {
     width: 100%;
 }
-
-.carouselDiv {
-    padding: 4rem;
-}
-
-.slick-slide img {
-    background-color: aqua;
-    max-height: 80vh;
-    width: 100vw;
-    padding: 0 20px;
-}
-
-.slick-slider .slick-list {
-    max-height: 80vh;
-}
-
-.slick-slider .slick-track {
-    max-height: 80vh;
-}
-
-.slick-prev:before, .slick-next:before {
-    font-family: 'slick';
-    font-size: 20px;
-    line-height: 1;
-    opacity: .75;
-    color: #c44;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-}
-
-
-/* .slick-slider {
-    background-color: aqua;
-} */

--- a/src/templates/HomePage.css
+++ b/src/templates/HomePage.css
@@ -13,3 +13,37 @@
 iframe {
     width: 100%;
 }
+
+.carouselDiv {
+    padding: 4rem;
+}
+
+.slick-slide img {
+    background-color: aqua;
+    max-height: 80vh;
+    width: 100vw;
+    padding: 0 20px;
+}
+
+.slick-slider .slick-list {
+    max-height: 80vh;
+}
+
+.slick-slider .slick-track {
+    max-height: 80vh;
+}
+
+.slick-prev:before, .slick-next:before {
+    font-family: 'slick';
+    font-size: 20px;
+    line-height: 1;
+    opacity: .75;
+    color: #c44;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+
+/* .slick-slider {
+    background-color: aqua;
+} */

--- a/src/templates/HomePage.css
+++ b/src/templates/HomePage.css
@@ -2,8 +2,6 @@
     .smallDisplay {
         display: none;
     }
-    
-    /* If we only want to limit the height of carousel for bigger screens. See more below */
     .carousel .slide img {
         max-height: 30vmax; 
         width: cover;
@@ -25,43 +23,3 @@
 iframe {
     width: 100%;
 }
-
-
-/* METHOD 1:
-    Since the images are too big on laptop and desktop screens, this limits the max height to be a ratio of the viewport making all 
-    images the same height. Setting width:0 adds black to both side of the image and keeps the aspect ratio the same
-    while not declaring width streteches the image to fill the width. Can also just be applied to larger screens insdie the media query above. */
-
-
-/* .carousel .slide img {
-    max-height: 30vmax; 
-    width: auto;
-}  */
-
-
-
-/* METHOD 2:
-    The first two below are a part of the background-image method. For our setup, I needed to put the image in html(since the carousel's 
-    height is determined by it's content) and make opacity of images 0 to properly use the background method.
-    See the bottom of HomePage.js for more info */
-
-/*.carousel-wrapper,
-.carousel,
-.carousel > .slider-wrapper,
-.carousel > .slider-wrapper > .slider {
-  height: 100%;
-} */
-
-/* .image-container {
-  height: 100%;
-  width: 100%;
-  background-repeat: no-repeat;
-  background-size: cover;
-  background-position: center;
-} */
-
-/* 
-.carousel .slide img {
-    max-height: 30vmax; 
-    opacity: 0
-} */

--- a/src/templates/HomePage.js
+++ b/src/templates/HomePage.js
@@ -2,27 +2,21 @@ import React from 'react'
 import { graphql } from 'gatsby'
 
 import './HomePage.css'
-import PageHeader from '../components/PageHeader'
 import Content from '../components/Content'
 import Layout from '../components/Layout'
 
 // Export Template for use in CMS preview
-export const HomePageTemplate = ({ title, subtitle, featuredImage, body }) => (
+export const HomePageTemplate = ({ title, subtitle, body }) => (
   <main className="Home">
-    <PageHeader
-      title={title}
-      subtitle={subtitle}
-      backgroundImage={featuredImage}
-    />
 
     <section className="section">
       <div className="container">
         <Content source={body} />
         <div className="smallDisplay">
-          <iframe src="https://calendar.google.com/calendar/b/4/embed?height=400&amp;wkst=1&amp;bgcolor=%23B39DDB&amp;ctz=America%2FChicago&amp;src=ZGV2dGVzdGVyMmsyMEBnbWFpbC5jb20&amp;color=%23039BE5&amp;showPrint=0&amp;showTabs=0&amp;showTz=0&amp;showCalendars=0&amp;mode=AGENDA&amp;title=Does%20title%20even%20matter%3F&amp;showTitle=0&amp;showDate=0&amp;showNav=1" className="mobileIframe" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+          <iframe src="https://calendar.google.com/calendar/b/4/embed?height=400&amp;wkst=1&amp;bgcolor=%23B39DDB&amp;ctz=America%2FChicago&amp;src=ZGV2dGVzdGVyMmsyMEBnbWFpbC5jb20&amp;color=%23039BE5&amp;showPrint=0&amp;showTabs=0&amp;showTz=0&amp;showCalendars=0&amp;mode=AGENDA&amp;title=Does%20title%20even%20matter%3F&amp;showTitle=0&amp;showDate=0&amp;showNav=1" className="mobileIframe" width="800" height="600" frameBorder="0" scrolling="no"></iframe>
         </div>
         <div className="largeDisplay">
-          <iframe src="https://calendar.google.com/calendar/b/4/embed?height=400&amp;wkst=1&amp;bgcolor=%23B39DDB&amp;ctz=America%2FChicago&amp;src=ZGV2dGVzdGVyMmsyMEBnbWFpbC5jb20&amp;color=%23039BE5&amp;showPrint=0&amp;showTabs=0&amp;showTz=0&amp;showCalendars=0&amp;mode=MONTH&amp;title=Does%20title%20even%20matter%3F&amp;showTitle=0&amp;showDate=0&amp;showNav=1" className="desktopIframe" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+          <iframe src="https://calendar.google.com/calendar/b/4/embed?height=400&amp;wkst=1&amp;bgcolor=%23B39DDB&amp;ctz=America%2FChicago&amp;src=ZGV2dGVzdGVyMmsyMEBnbWFpbC5jb20&amp;color=%23039BE5&amp;showPrint=0&amp;showTabs=0&amp;showTz=0&amp;showCalendars=0&amp;mode=MONTH&amp;title=Does%20title%20even%20matter%3F&amp;showTitle=0&amp;showDate=0&amp;showNav=1" className="desktopIframe" width="800" height="600" frameBorder="0" scrolling="no"></iframe>
         </div>
       </div>
     </section>
@@ -50,7 +44,6 @@ export const pageQuery = graphql`
       frontmatter {
         title
         subtitle
-        featuredImage
       }
     }
   }

--- a/src/templates/HomePage.js
+++ b/src/templates/HomePage.js
@@ -1,16 +1,40 @@
 import React from 'react'
 import { graphql } from 'gatsby'
 
+import Slider from 'react-slick'
+import 'slick-carousel/slick/slick.css'
+import 'slick-carousel/slick/slick-theme.css'
+
 import './HomePage.css'
+import Image from '../components/Image'
 import Content from '../components/Content'
 import Layout from '../components/Layout'
+import _kebabCase from 'lodash/kebabCase'
+
 
 // Export Template for use in CMS preview
-export const HomePageTemplate = ({ title, subtitle, body }) => (
-  <main className="Home">
+export const HomePageTemplate = ({ title, carousel, body }) => { 
+  const renderSlides = () => carousel.images.map((images, index) => {
+    return (
+    <div key={_kebabCase(images.alt) + '-' + index}>
+       <Image lazy={false} src={images.image} alt={images.alt} key={_kebabCase(images.alt) + '-' + index + '-' + index}/>
+    </div>
+  )})
+  var settings = {
+    dots: true,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+  };
+  return (
+  <main className="Home">   
+    
+    <div style={{margin: '4rem'}}>
+      <Slider {...settings}>{renderSlides()}</Slider>
+    </div>
 
     <section className="section">
       <div className="container">
+        <h1>{title}</h1>
         <Content source={body} />
         <div className="smallDisplay">
           <iframe src="https://calendar.google.com/calendar/b/4/embed?height=400&amp;wkst=1&amp;bgcolor=%23B39DDB&amp;ctz=America%2FChicago&amp;src=ZGV2dGVzdGVyMmsyMEBnbWFpbC5jb20&amp;color=%23039BE5&amp;showPrint=0&amp;showTabs=0&amp;showTz=0&amp;showCalendars=0&amp;mode=AGENDA&amp;title=Does%20title%20even%20matter%3F&amp;showTitle=0&amp;showDate=0&amp;showNav=1" className="mobileIframe" width="800" height="600" frameBorder="0" scrolling="no"></iframe>
@@ -21,7 +45,8 @@ export const HomePageTemplate = ({ title, subtitle, body }) => (
       </div>
     </section>
   </main>
-)
+  )
+}
 
 // Export Default HomePage for front-end
 const HomePage = ({ data: { page } }) => (
@@ -43,7 +68,12 @@ export const pageQuery = graphql`
       html
       frontmatter {
         title
-        subtitle
+        carousel {
+          images {
+            image
+            alt
+          }
+        }
       }
     }
   }

--- a/src/templates/HomePage.js
+++ b/src/templates/HomePage.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { graphql } from 'gatsby'
-import Image from '../components/Image'
 import Content from '../components/Content'
 import Layout from '../components/Layout'
 import _kebabCase from 'lodash/kebabCase'
@@ -11,24 +10,30 @@ import './HomePage.css'
 
 // Export Template for use in CMS preview
 export const HomePageTemplate = ({ title, carousel, body }) => { 
-  const renderSlides = () => carousel.images.map((images, index) => {
+  const renderSlides = () => carousel.images.concat(carousel.images).map((images, index) => {
   return (
     <div key={_kebabCase(images.alt) + '-' + index}>
       <img
         src={images.image} 
         alt={images.alt}  
         loading="lazy"/>
-      <p className="legend">Legend {index+1}</p>
+      <p className="legend">{images.alt}</p>
 
     </div>
   )})
 
   return (
   <main className="Home">
-    <Carousel className="carousel-wrapper" showArrows={true} dynamicHeight={true} autoPlay={true} infiniteLoop={true} 
+    
+    <Carousel className="carousel-smallDisplay" showArrows={true} dynamicHeight={true} autoPlay={true} infiniteLoop={true} 
       showThumbs={false} showStatus={false}>
       {renderSlides()}
     </Carousel>
+
+    <Carousel className="carousel-largeDisplay"  centerMode centerSlidePercentage="40" autoPlay={true} showArrows={true} infiniteLoop={true} showThumbs={false} showStatus={false}>
+      {renderSlides()}
+    </Carousel>
+
     <section className="section">
       <div className="container">
         <h1>{title}</h1>

--- a/src/templates/HomePage.js
+++ b/src/templates/HomePage.js
@@ -14,15 +14,19 @@ export const HomePageTemplate = ({ title, carousel, body }) => {
   const renderSlides = () => carousel.images.map((images, index) => {
   return (
     <div key={_kebabCase(images.alt) + '-' + index}>
-      <img src={images.image} />
-      <p className="legend">Legend {index}</p>
+      <img
+        src={images.image} 
+        alt={images.alt}  
+        loading="lazy"/>
+      <p className="legend">Legend {index+1}</p>
 
     </div>
   )})
 
   return (
   <main className="Home">
-    <Carousel showArrows={true}>
+    <Carousel className="carousel-wrapper" showArrows={true} dynamicHeight={true} autoPlay={true} infiniteLoop={true} 
+      showThumbs={false} showStatus={false}>
       {renderSlides()}
     </Carousel>
     <section className="section">
@@ -71,3 +75,18 @@ export const pageQuery = graphql`
     }
   }
 `
+
+// A method that put the image in the background. The carousel however won't appear if it's just a div, since the size of the carousel is
+//  dependent on the size of it's content, so the only way to fully use this method is to put the images inside the div but make their
+// opacity 0
+  // const renderSlides = () => carousel.images.map((images, index) => {
+  //   return (
+  //     <div className="image-container" key={_kebabCase(images.alt) + '-' + index}
+  //      style={{ backgroundImage: `url(${images.image})` }} >
+  //       <img
+  //         src={images.image} 
+  //         alt={images.alt}  
+  //         loading="lazy"/>
+  //       <p className="legend">Legend {index+1}</p>
+  //     </div>
+  //   )})

--- a/src/templates/HomePage.js
+++ b/src/templates/HomePage.js
@@ -80,18 +80,3 @@ export const pageQuery = graphql`
     }
   }
 `
-
-// A method that put the image in the background. The carousel however won't appear if it's just a div, since the size of the carousel is
-//  dependent on the size of it's content, so the only way to fully use this method is to put the images inside the div but make their
-// opacity 0
-  // const renderSlides = () => carousel.images.map((images, index) => {
-  //   return (
-  //     <div className="image-container" key={_kebabCase(images.alt) + '-' + index}
-  //      style={{ backgroundImage: `url(${images.image})` }} >
-  //       <img
-  //         src={images.image} 
-  //         alt={images.alt}  
-  //         loading="lazy"/>
-  //       <p className="legend">Legend {index+1}</p>
-  //     </div>
-  //   )})

--- a/src/templates/HomePage.js
+++ b/src/templates/HomePage.js
@@ -1,15 +1,11 @@
 import React from 'react'
 import { graphql } from 'gatsby'
-
-import Slider from 'react-slick'
-import 'slick-carousel/slick/slick.css'
-import 'slick-carousel/slick/slick-theme.css'
-
-import './HomePage.css'
 import Image from '../components/Image'
 import Content from '../components/Content'
 import Layout from '../components/Layout'
 import _kebabCase from 'lodash/kebabCase'
+import { Carousel } from 'react-responsive-carousel';
+import "react-responsive-carousel/lib/styles/carousel.min.css";
 import './HomePage.css'
 
 
@@ -18,31 +14,17 @@ export const HomePageTemplate = ({ title, carousel, body }) => {
   const renderSlides = () => carousel.images.map((images, index) => {
   return (
     <div key={_kebabCase(images.alt) + '-' + index}>
-      <Image
-          // resolution="small"
-          lazy={false}
-          src={images.image} 
-          alt={images.alt} 
-          key={_kebabCase(images.alt) + '-' + index + '-' + index}
-        />
+      <img src={images.image} />
+      <p className="legend">Legend {index}</p>
+
     </div>
   )})
 
-  var settings = {
-    dots: true,
-    // lazyLoad: true,
-    infinite: true,
-    slidesToShow: 1,
-    slidesToScroll: 1,
-  };
-
   return (
-  <main className="Home">   
-    
-    <div className="carouselDiv">
-      <Slider {...settings}>{renderSlides()}</Slider>
-    </div>
-
+  <main className="Home">
+    <Carousel showArrows={true}>
+      {renderSlides()}
+    </Carousel>
     <section className="section">
       <div className="container">
         <h1>{title}</h1>

--- a/src/templates/HomePage.js
+++ b/src/templates/HomePage.js
@@ -10,25 +10,36 @@ import Image from '../components/Image'
 import Content from '../components/Content'
 import Layout from '../components/Layout'
 import _kebabCase from 'lodash/kebabCase'
+import './HomePage.css'
 
 
 // Export Template for use in CMS preview
 export const HomePageTemplate = ({ title, carousel, body }) => { 
   const renderSlides = () => carousel.images.map((images, index) => {
-    return (
+  return (
     <div key={_kebabCase(images.alt) + '-' + index}>
-       <Image lazy={false} src={images.image} alt={images.alt} key={_kebabCase(images.alt) + '-' + index + '-' + index}/>
+      <Image
+          // resolution="small"
+          lazy={false}
+          src={images.image} 
+          alt={images.alt} 
+          key={_kebabCase(images.alt) + '-' + index + '-' + index}
+        />
     </div>
   )})
+
   var settings = {
     dots: true,
+    // lazyLoad: true,
+    infinite: true,
     slidesToShow: 1,
     slidesToScroll: 1,
   };
+
   return (
   <main className="Home">   
     
-    <div style={{margin: '4rem'}}>
+    <div className="carouselDiv">
       <Slider {...settings}>{renderSlides()}</Slider>
     </div>
 

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -193,6 +193,7 @@ collections: # A list of collections the CMS should be able to edit
                 widget: list
                 fields: 
                   - { label: Image, name: image, widget: image }
+                  - { label: Alternate, name: alt, widget: string, required: true }
           - { label: Slug, name: slug, widget: hidden, default: '' }
           - { label: Title, name: title, widget: string }
           - { label: Subtitle, name: subtitle, widget: markdown, required: false }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -191,7 +191,7 @@ collections: # A list of collections the CMS should be able to edit
               - label: Images
                 name: images
                 widget: list
-                field: 
+                fields: 
                   - { label: Image, name: image, widget: image }
           - { label: Slug, name: slug, widget: hidden, default: '' }
           - { label: Title, name: title, widget: string }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -184,6 +184,15 @@ collections: # A list of collections the CMS should be able to edit
               widget: hidden,
               default: HomePage,
             }
+          - label: 'Carousel'
+            name: 'carousel' 
+            widget: object
+            fields:
+              - label: Images
+                name: images
+                widget: list
+                field: 
+                  - { label: Image, name: image, widget: image }
           - { label: Slug, name: slug, widget: hidden, default: '' }
           - { label: Title, name: title, widget: string }
           - { label: Subtitle, name: subtitle, widget: markdown, required: false }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -186,7 +186,6 @@ collections: # A list of collections the CMS should be able to edit
             }
           - { label: Slug, name: slug, widget: hidden, default: '' }
           - { label: Title, name: title, widget: string }
-          - { label: Featured Image, name: featuredImage, widget: image }
           - { label: Subtitle, name: subtitle, widget: markdown, required: false }
           - { label: Body, name: body, widget: markdown }
           - label: 'Accordion'


### PR DESCRIPTION
In Draft PR #45, I was experimenting with implementing a carousel component built with React. It came to my attention later that it might be possible to get the same result by combining the Netlify image widget with a [variable type of list widget](https://www.netlifycms.org/docs/beta-features/#list-widget-variable-types). The feature is listed as a beta feature, but it's worth trying out.