### PR TITLE
Calendar

### DIFF
--- a/src/components/Calendar.css
+++ b/src/components/Calendar.css
@@ -1,0 +1,15 @@
+@media (min-width: 550px) {
+    .smallDisplay {
+        display: none;
+    }
+ }
+
+ @media (max-width: 550px) {
+    .largeDisplay {
+        display: none;
+    }
+ }
+
+iframe {
+    width: 100%;
+}

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import './calendar.css'
 
 const googleCalendar = (props) => {
 
@@ -12,7 +13,7 @@ const googleCalendar = (props) => {
             </div>
         </div>
     )
-    
+
 }
 
 export default googleCalendar;

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -6,10 +6,10 @@ const GoogleCalendar = (props) => {
     return (
         <div>
             <div className="smallDisplay">
-                <iframe src="https://calendar.google.com/calendar/b/4/embed?height=400&amp;wkst=1&amp;bgcolor=%23B39DDB&amp;ctz=America%2FChicago&amp;src=ZGV2dGVzdGVyMmsyMEBnbWFpbC5jb20&amp;color=%23039BE5&amp;showPrint=0&amp;showTabs=0&amp;showTz=0&amp;showCalendars=0&amp;mode=AGENDA&amp;title=Does%20title%20even%20matter%3F&amp;showTitle=0&amp;showDate=0&amp;showNav=1" className="mobileIframe" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+                <iframe src="https://calendar.google.com/calendar/b/4/embed?height=400&amp;wkst=1&amp;bgcolor=%23B39DDB&amp;ctz=America%2FChicago&amp;src=ZGV2dGVzdGVyMmsyMEBnbWFpbC5jb20&amp;color=%23039BE5&amp;showPrint=0&amp;showTabs=0&amp;showTz=0&amp;showCalendars=0&amp;mode=AGENDA&amp;title=Does%20title%20even%20matter%3F&amp;showTitle=0&amp;showDate=0&amp;showNav=1" className="mobileIframe" width="800" height="600" frameBorder="0" scrolling="no"></iframe>
             </div>
             <div className="largeDisplay">
-                <iframe src="https://calendar.google.com/calendar/b/4/embed?height=400&amp;wkst=1&amp;bgcolor=%23B39DDB&amp;ctz=America%2FChicago&amp;src=ZGV2dGVzdGVyMmsyMEBnbWFpbC5jb20&amp;color=%23039BE5&amp;showPrint=0&amp;showTabs=0&amp;showTz=0&amp;showCalendars=0&amp;mode=MONTH&amp;title=Does%20title%20even%20matter%3F&amp;showTitle=0&amp;showDate=0&amp;showNav=1" className="desktopIframe" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+                <iframe src="https://calendar.google.com/calendar/b/4/embed?height=400&amp;wkst=1&amp;bgcolor=%23B39DDB&amp;ctz=America%2FChicago&amp;src=ZGV2dGVzdGVyMmsyMEBnbWFpbC5jb20&amp;color=%23039BE5&amp;showPrint=0&amp;showTabs=0&amp;showTz=0&amp;showCalendars=0&amp;mode=MONTH&amp;title=Does%20title%20even%20matter%3F&amp;showTitle=0&amp;showDate=0&amp;showNav=1" className="desktopIframe" width="800" height="600" frameBorder="0" scrolling="no"></iframe>
             </div>
         </div>
     )

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import './calendar.css'
 
-const googleCalendar = (props) => {
+const GoogleCalendar = (props) => {
 
     return (
         <div>
@@ -16,4 +16,4 @@ const googleCalendar = (props) => {
 
 }
 
-export default googleCalendar;
+export default GoogleCalendar;

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const googleCalendar = (props) => {
+
+    return (
+        <div>
+            <div className="smallDisplay">
+                <iframe src="https://calendar.google.com/calendar/b/4/embed?height=400&amp;wkst=1&amp;bgcolor=%23B39DDB&amp;ctz=America%2FChicago&amp;src=ZGV2dGVzdGVyMmsyMEBnbWFpbC5jb20&amp;color=%23039BE5&amp;showPrint=0&amp;showTabs=0&amp;showTz=0&amp;showCalendars=0&amp;mode=AGENDA&amp;title=Does%20title%20even%20matter%3F&amp;showTitle=0&amp;showDate=0&amp;showNav=1" className="mobileIframe" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+            </div>
+            <div className="largeDisplay">
+                <iframe src="https://calendar.google.com/calendar/b/4/embed?height=400&amp;wkst=1&amp;bgcolor=%23B39DDB&amp;ctz=America%2FChicago&amp;src=ZGV2dGVzdGVyMmsyMEBnbWFpbC5jb20&amp;color=%23039BE5&amp;showPrint=0&amp;showTabs=0&amp;showTz=0&amp;showCalendars=0&amp;mode=MONTH&amp;title=Does%20title%20even%20matter%3F&amp;showTitle=0&amp;showDate=0&amp;showNav=1" className="desktopIframe" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+            </div>
+        </div>
+    )
+    
+}
+
+export default googleCalendar;

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import './calendar.css'
+import './Calendar.css'
 
 const GoogleCalendar = (props) => {
 

--- a/src/components/Content.js
+++ b/src/components/Content.js
@@ -80,7 +80,6 @@ const Content = ({ source, src, className = '' }) => {
         className={`Content ${className}`}
         dangerouslySetInnerHTML={{ __html: source }}
       />
-        <GoogleCalendar />
       </React.Fragment>
     )
   }

--- a/src/components/Content.js
+++ b/src/components/Content.js
@@ -3,6 +3,7 @@ import ReactDOMServer from 'react-dom/server'
 import Marked from 'react-markdown'
 import PropTypes from 'prop-types'
 import Image from './Image'
+import GoogleCalendar from './Calendar'
 
 import './Content.css'
 
@@ -79,12 +80,7 @@ const Content = ({ source, src, className = '' }) => {
         className={`Content ${className}`}
         dangerouslySetInnerHTML={{ __html: source }}
       />
-        <div className="smallDisplay">
-          <iframe src="https://calendar.google.com/calendar/b/4/embed?height=400&amp;wkst=1&amp;bgcolor=%23B39DDB&amp;ctz=America%2FChicago&amp;src=ZGV2dGVzdGVyMmsyMEBnbWFpbC5jb20&amp;color=%23039BE5&amp;showPrint=0&amp;showTabs=0&amp;showTz=0&amp;showCalendars=0&amp;mode=AGENDA&amp;title=Does%20title%20even%20matter%3F&amp;showTitle=0&amp;showDate=0&amp;showNav=1" className="mobileIframe" width="800" height="600" frameborder="0" scrolling="no"></iframe>
-        </div>
-        <div className="largeDisplay">
-          <iframe src="https://calendar.google.com/calendar/b/4/embed?height=400&amp;wkst=1&amp;bgcolor=%23B39DDB&amp;ctz=America%2FChicago&amp;src=ZGV2dGVzdGVyMmsyMEBnbWFpbC5jb20&amp;color=%23039BE5&amp;showPrint=0&amp;showTabs=0&amp;showTz=0&amp;showCalendars=0&amp;mode=MONTH&amp;title=Does%20title%20even%20matter%3F&amp;showTitle=0&amp;showDate=0&amp;showNav=1" className="desktopIframe" width="800" height="600" frameborder="0" scrolling="no"></iframe>
-        </div>
+        <GoogleCalendar />
       </React.Fragment>
     )
   }

--- a/src/templates/HomePage.js
+++ b/src/templates/HomePage.js
@@ -5,6 +5,7 @@ import './HomePage.css'
 import PageHeader from '../components/PageHeader'
 import Content from '../components/Content'
 import Layout from '../components/Layout'
+import GoogleCalendar from '../components/Calendar'
 
 // Export Template for use in CMS preview
 export const HomePageTemplate = ({ title, subtitle, featuredImage, body }) => (
@@ -19,7 +20,7 @@ export const HomePageTemplate = ({ title, subtitle, featuredImage, body }) => (
     <section className="section">
       <div className="container">
         <Content source={body} />
-        
+        <GoogleCalendar />
       </div>
     </section>
   </main>


### PR DESCRIPTION
The calendar iframe was originally hardcoded into the home page markdown. This was not appropriate for making it responsive to different displays (as defined by the iframe's styling). It was then moved into the content component, but was rendered on many inappropriate pages. We decided it was best to create a  component for the calendar, so it was created and then embedded in the HomePage template.